### PR TITLE
Anonymous collection creation, root catalog configuration, etc

### DIFF
--- a/src/Application/Catalogs/Queries/GetRootCatalogQuery.cs
+++ b/src/Application/Catalogs/Queries/GetRootCatalogQuery.cs
@@ -8,12 +8,16 @@ public class GetRootCatalogQueryHandler
     : IRequestHandler<GetRootCatalogQuery, RootCatalogDto>
 {
     private readonly IApplicationDbContext _context;
+    private readonly IRootCatalogService _root;
     private readonly IUrlService _url;
 
-    public GetRootCatalogQueryHandler(IApplicationDbContext context,
-                                      IUrlService url)
+    public GetRootCatalogQueryHandler(
+        IApplicationDbContext context,
+        IRootCatalogService root,                                
+        IUrlService url)
     {
         _context = context;
+        _root = root;
         _url = url;
     }
 
@@ -26,13 +30,12 @@ public class GetRootCatalogQueryHandler
 
         var links = await GenerateLinks(collecs);
 
-        //< TODO - Change the StacVersion / ID / Title into configuration variables that are pulled in
         var dto = new RootCatalogDto
         {
-            StacVersion = "1.0.0",
-            Identifier = "haystac",
-            Title = "Root catalog for Haytstac API",
-            Description = "A descriptive message about the Haystac landing page",
+            StacVersion = _root.StacVersion,
+            Identifier = _root.Identifier,
+            Title = _root.Title,
+            Description = _root.Description,
             Type = "Catalog",
             ConformsTo = new List<string>
             {
@@ -71,14 +74,14 @@ public class GetRootCatalogQueryHandler
             },
             new Link
             {
-                Relationship = "self",
+                Relationship = "search",
                 Href = $"{baseUrl}/search",
                 Type = "application/geo+json",
                 Method = "GET"
             },
             new Link
             {
-                Relationship = "self",
+                Relationship = "search",
                 Href = $"{baseUrl}/search",
                 Type = "application/geo+json",
                 Method = "POST"

--- a/src/Application/Collections/Commands/CreateCollectionCommand.cs
+++ b/src/Application/Collections/Commands/CreateCollectionCommand.cs
@@ -3,6 +3,8 @@
 public record CreateCollectionCommand : IRequest<Guid>
 {
     public CollectionDto Dto { get; set; } = null!;
+
+    public bool Anonymous { get; set; } = false;
 }
 
 public class CreateCollectionCommandHandler 
@@ -23,7 +25,10 @@ public class CreateCollectionCommandHandler
     {
         var entity = command.Dto.ToCollection();
 
-        entity.ClientId = await _clients.GetClientIdAsync();
+        if (!command.Anonymous)
+        {
+            entity.ClientId = await _clients.GetClientIdAsync();
+        }
 
         entity.AddDomainEvent(new CollectionAddedEvent(entity));
 

--- a/src/Application/Common/Interfaces/IRootCatalogService.cs
+++ b/src/Application/Common/Interfaces/IRootCatalogService.cs
@@ -1,0 +1,9 @@
+﻿namespace Haystac.Application.Common.Interfaces;
+
+public interface IRootCatalogService
+{
+    string StacVersion { get; }
+    string Identifier { get; }
+    string Title { get; }
+    string Description { get; }
+}

--- a/src/Console/Application/Collections/CollectionAddCommand.cs
+++ b/src/Console/Application/Collections/CollectionAddCommand.cs
@@ -7,6 +7,10 @@ public class CollectionAddCommand : AsyncCommand<CollectionAddCommand.Settings>
         [CommandArgument(0, "<JSONFILE>")]
         [Description("Path to input STAC Collection JSON file to be parsed")]
         public string JsonFile { get; set; } = string.Empty;
+
+        [CommandOption("-a|--anon")]
+        [DefaultValue(false)]
+        public bool Anonymous { get; set; }
     }
 
     private readonly ICollectionRepository _collections;
@@ -29,7 +33,7 @@ public class CollectionAddCommand : AsyncCommand<CollectionAddCommand.Settings>
 
         Helper.Write($"Attempting to create Collection: [yellow]{dto.Identifier.EscapeMarkup()}[/]");
 
-        var id = await _collections.CreateCollectionAsync(dto);
+        var id = await _collections.CreateCollectionAsync(dto, settings.Anonymous);
 
         Helper.Write($"\t - Created with UUID: [yellow]{id}[/]");
 

--- a/src/Console/Infrastructure/Repositories/CollectionRepository.cs
+++ b/src/Console/Infrastructure/Repositories/CollectionRepository.cs
@@ -9,12 +9,12 @@ public class CollectionRepository : ICollectionRepository
         _client = client;
     }
 
-    public async Task<Guid> CreateCollectionAsync(CollectionDto dto)
+    public async Task<Guid> CreateCollectionAsync(CollectionDto dto, bool isAnonymous = false)
     {
         var json = JsonSerializer.Serialize(dto);
         var requestContent = new StringContent(json, Encoding.UTF8, "application/json");
 
-        var route = $"{dto.Identifier}";
+        var route = $"{dto.Identifier}?anonymous={isAnonymous}";
         var response = await _client.PostAsync(route, requestContent);
         var responseBody = await response.Content.ReadAsStringAsync();
 

--- a/src/Console/Infrastructure/Repositories/Interfaces/ICollectionRepository.cs
+++ b/src/Console/Infrastructure/Repositories/Interfaces/ICollectionRepository.cs
@@ -2,7 +2,7 @@
 
 public interface ICollectionRepository
 {
-    public Task<Guid> CreateCollectionAsync(CollectionDto dto);
+    public Task<Guid> CreateCollectionAsync(CollectionDto dto, bool isAnonymous = false);
     public Task<List<CollectionDto>> GetAllCollectionsAsync();
     public Task<CollectionDto> GetCollectionByIdAsync(string collectionId);
     public Task UpdateCollectionAsync(CollectionDto dto);

--- a/src/Infrastructure/ConfigureServices.cs
+++ b/src/Infrastructure/ConfigureServices.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 
 using Npgsql;
@@ -21,6 +20,9 @@ public static class ConfigureServices
     {
         services.AddTransient<IDateTimeService, DateTimeService>();
         services.AddTransient<IClientService, ClientService>();
+
+        services.Configure<RootCatalogOptions>(configuration.GetSection(RootCatalogOptions.RootCatalog));
+        services.AddSingleton<IRootCatalogService, RootCatalogService>();
 
         //< TODO - Consider injecting an in-memory DB for testing
         var datasourceBuilder = new NpgsqlDataSourceBuilder(configuration.GetConnectionString("DefaultConnection"));

--- a/src/Infrastructure/Services/RootCatalogService.cs
+++ b/src/Infrastructure/Services/RootCatalogService.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Extensions.Options;
+
+namespace Haystac.Infrastructure.Services;
+
+public class RootCatalogOptions
+{
+    public const string RootCatalog = "RootCatalog";
+
+    public const string DefaultVersion = "1.0.0";
+    public const string DefaultIdentifier = "haystac";
+    public const string DefaultTitle = "Root catalog for Haytstac API";
+    public const string DefaultDescription = "A descriptive message about the Haystac landing page";
+
+    public string StacVersion { get; set; } = DefaultVersion;
+    public string Identifier { get; set; } = DefaultIdentifier;
+    public string Title { get; set; } = DefaultTitle;
+    public string Description { get; set; } = DefaultDescription;
+}
+
+public class RootCatalogService : IRootCatalogService
+{
+    private readonly RootCatalogOptions _options;
+
+    public RootCatalogService(IOptions<RootCatalogOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public string StacVersion => _options.StacVersion;
+    public string Identifier => _options.Identifier;
+    public string Title => _options.Title;
+    public string Description => _options.Description;
+}

--- a/src/WebApi/Controllers/CollectionsController.cs
+++ b/src/WebApi/Controllers/CollectionsController.cs
@@ -29,11 +29,14 @@ public class CollectionsController : ControllerBase
 
     [Authorize]
     [HttpPost("{id}")]
-    public async Task<ActionResult<Guid>> CreateCollection([FromBody] CollectionDto dto, string id)
+    public async Task<ActionResult<Guid>> CreateCollection(
+        [FromBody] CollectionDto dto,
+        string id,
+        [FromQuery] bool anonymous = false)
     {
         if (dto.Identifier != id) return BadRequest($"Payload CollectionID doesn't match route CollectionID");
 
-        return await _mediator.Send(new CreateCollectionCommand { Dto = dto });
+        return await _mediator.Send(new CreateCollectionCommand { Dto = dto, Anonymous = anonymous });
     }
 
     [Authorize]

--- a/src/WebApi/appsettings.json
+++ b/src/WebApi/appsettings.json
@@ -6,6 +6,12 @@
     "Issuer": "TestIssuer",
     "Audience": "TestAudience"
   },
+  "RootCatalog": {
+    "StacVersion": "1.0.0",
+    "Identifier": "haystac",
+    "Title": "Root catalog for Haytstac API",
+    "Description": "A configured message about the Haystac landing page"
+  },
   "ConnectionStrings": {
     "DefaultConnection": "host=localhost;port=5432;database=haystac-test;username=postgres;password=ponos"
   },


### PR DESCRIPTION
Closes #24

- Added configuration of 'RootCatalog' via `appsettings.json` as well as ENV VARs
- Added optional 'anonymous' query parameter when creating collections via `POST` to indicate if the new collection is anonymous or not
- Other minor fixes and refactoring